### PR TITLE
feat: support Douyin product link

### DIFF
--- a/cli_main.py
+++ b/cli_main.py
@@ -67,7 +67,7 @@ async def main():
         elif args.platform == SOCIAL_MEDIA_KUAISHOU:
             await ks_setup(str(account_file), handle=True)
     elif args.action == 'upload':
-        title, tags = get_title_and_hashtags(args.video_file)
+        title, tags, product_url, product_title = get_title_and_hashtags(args.video_file)
         video_file = args.video_file
 
         if args.publish_type == 0:
@@ -79,7 +79,8 @@ async def main():
 
         if args.platform == SOCIAL_MEDIA_DOUYIN:
             await douyin_setup(account_file, handle=False)
-            app = DouYinVideo(title, video_file, tags, publish_date, account_file)
+            app = DouYinVideo(title, video_file, tags, publish_date, account_file,
+                              product_url=product_url, product_title=product_title)
         elif args.platform == SOCIAL_MEDIA_TIKTOK:
             await tiktok_setup(account_file, handle=True)
             app = TiktokVideo(title, video_file, tags, publish_date, account_file)

--- a/examples/upload_video_to_baijiahao.py
+++ b/examples/upload_video_to_baijiahao.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     publish_datetimes = generate_schedule_time_next_day(file_num, 1, daily_times=[16])
     cookie_setup = asyncio.run(baijiahao_setup(account_file, handle=False))
     for index, file in enumerate(files):
-        title, tags = get_title_and_hashtags(str(file))
+        title, tags, _, _ = get_title_and_hashtags(str(file))
         thumbnail_path = file.with_suffix('.png')
         # 打印视频文件名、标题和 hashtag
         print(f"视频文件名：{file}")

--- a/examples/upload_video_to_bilibili.py
+++ b/examples/upload_video_to_bilibili.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     timestamps = generate_schedule_time_next_day(file_num, 1, daily_times=[16], timestamps=True)
 
     for index, file in enumerate(files):
-        title, tags = get_title_and_hashtags(str(file))
+        title, tags, _, _ = get_title_and_hashtags(str(file))
         # just avoid error, bilibili don't allow same title of video.
         title += random_emoji()
         tags_str = ','.join([tag for tag in tags])

--- a/examples/upload_video_to_douyin.py
+++ b/examples/upload_video_to_douyin.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     publish_datetimes = generate_schedule_time_next_day(file_num, 1, daily_times=[16])
     cookie_setup = asyncio.run(douyin_setup(account_file, handle=False))
     for index, file in enumerate(files):
-        title, tags = get_title_and_hashtags(str(file))
+        title, tags, product_url, product_title = get_title_and_hashtags(str(file))
         thumbnail_path = file.with_suffix('.png')
         # 打印视频文件名、标题和 hashtag
         print(f"视频文件名：{file}")
@@ -27,5 +27,6 @@ if __name__ == '__main__':
         # if thumbnail_path.exists():
             # app = DouYinVideo(title, file, tags, publish_datetimes[index], account_file, thumbnail_path=thumbnail_path)
         # else:
-        app = DouYinVideo(title, file, tags, publish_datetimes[index], account_file)
+        app = DouYinVideo(title, file, tags, publish_datetimes[index], account_file,
+                           product_url=product_url, product_title=product_title)
         asyncio.run(app.main(), debug=False)

--- a/examples/upload_video_to_kuaishou.py
+++ b/examples/upload_video_to_kuaishou.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     publish_datetimes = generate_schedule_time_next_day(file_num, 1, daily_times=[16])
     cookie_setup = asyncio.run(ks_setup(account_file, handle=False))
     for index, file in enumerate(files):
-        title, tags = get_title_and_hashtags(str(file))
+        title, tags, _, _ = get_title_and_hashtags(str(file))
         # 打印视频文件名、标题和 hashtag
         print(f"视频文件名：{file}")
         print(f"标题：{title}")

--- a/examples/upload_video_to_tencent.py
+++ b/examples/upload_video_to_tencent.py
@@ -19,7 +19,7 @@ if __name__ == '__main__':
     cookie_setup = asyncio.run(weixin_setup(account_file, handle=True))
     category = TencentZoneTypes.LIFESTYLE.value  # 标记原创需要否则不需要传
     for index, file in enumerate(files):
-        title, tags = get_title_and_hashtags(str(file))
+        title, tags, _, _ = get_title_and_hashtags(str(file))
         # 打印视频文件名、标题和 hashtag
         print(f"视频文件名：{file}")
         print(f"标题：{title}")

--- a/examples/upload_video_to_tiktok.py
+++ b/examples/upload_video_to_tiktok.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     publish_datetimes = generate_schedule_time_next_day(file_num, 1, daily_times=[16])
     cookie_setup = asyncio.run(tiktok_setup(account_file, handle=True))
     for index, file in enumerate(files):
-        title, tags = get_title_and_hashtags(str(file))
+        title, tags, _, _ = get_title_and_hashtags(str(file))
         thumbnail_path = file.with_suffix('.png')
         print(f"video_file_name：{file}")
         print(f"video_title：{title}")

--- a/examples/upload_video_to_xhs.py
+++ b/examples/upload_video_to_xhs.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     publish_datetimes = generate_schedule_time_next_day(file_num, 1, daily_times=[16])
 
     for index, file in enumerate(files):
-        title, tags = get_title_and_hashtags(str(file))
+        title, tags, _, _ = get_title_and_hashtags(str(file))
         # 加入到标题 补充标题（xhs 可以填1000字不写白不写）
         tags_str = ' '.join(['#' + tag for tag in tags])
         hash_tags_str = ''
@@ -57,11 +57,13 @@ if __name__ == '__main__':
 
         hash_tags_str = ' ' + ' '.join(['#' + tag + '[话题]#' for tag in hash_tags])
 
-        note = xhs_client.create_video_note(title=title[:20], video_path=str(file),
-                                            desc=title + tags_str + hash_tags_str,
-                                            topics=topics,
-                                            is_private=False,
-                                            post_time=publish_datetimes[index].strftime("%Y-%m-%d %H:%M:%S"))
+        note = xhs_client.create_video_note(
+            title=title[:20], video_path=str(file),
+            desc=title + tags_str + hash_tags_str,
+            topics=topics,
+            is_private=False,
+            post_time=publish_datetimes[index].strftime("%Y-%m-%d %H:%M:%S")
+        )
 
         beauty_print(note)
         # 强制休眠30s，避免风控（必要）

--- a/examples/upload_video_to_xiaohongshu.py
+++ b/examples/upload_video_to_xiaohongshu.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     publish_datetimes = generate_schedule_time_next_day(file_num, 1, daily_times=[16])
     cookie_setup = asyncio.run(xiaohongshu_setup(account_file, handle=False))
     for index, file in enumerate(files):
-        title, tags = get_title_and_hashtags(str(file))
+        title, tags, _, _ = get_title_and_hashtags(str(file))
         thumbnail_path = file.with_suffix('.png')
         # 打印视频文件名、标题和 hashtag
         print(f"视频文件名：{file}")

--- a/myUtils/postVideo.py
+++ b/myUtils/postVideo.py
@@ -44,7 +44,7 @@ def post_video_DouYin(title,files,tags,account_file,category=TencentZoneTypes.LI
             print(f"视频文件名：{file}")
             print(f"标题：{title}")
             print(f"Hashtag：{tags}")
-            app = DouYinVideo(title, str(file), tags, publish_datetimes[index], cookie, category)
+            app = DouYinVideo(title, str(file), tags, publish_datetimes[index], cookie)
             asyncio.run(app.main(), debug=False)
 
 

--- a/utils/files_times.py
+++ b/utils/files_times.py
@@ -20,7 +20,7 @@ def get_title_and_hashtags(filename):
     filename: 视频文件名
 
   Returns:
-    视频标题和 hashtag 列表
+    视频标题、hashtag 列表、商品链接、商品短标题
   """
 
     # 获取视频标题和 hashtag txt 文件名
@@ -30,12 +30,14 @@ def get_title_and_hashtags(filename):
     with open(txt_filename, "r", encoding="utf-8") as f:
         content = f.read()
 
-    # 获取标题和 hashtag
+    # 获取标题、hashtag及商品信息
     splite_str = content.strip().split("\n")
-    title = splite_str[0]
-    hashtags = splite_str[1].replace("#", "").split(" ")
+    title = splite_str[0] if len(splite_str) > 0 else ""
+    hashtags = splite_str[1].replace("#", "").split(" ") if len(splite_str) > 1 else []
+    product_url = splite_str[2] if len(splite_str) > 2 else None
+    product_title = splite_str[3] if len(splite_str) > 3 else None
 
-    return title, hashtags
+    return title, hashtags, product_url, product_title
 
 
 def generate_schedule_time_next_day(total_videos, videos_per_day = 1, daily_times=None, timestamps=False, start_days=0):


### PR DESCRIPTION
## Summary
- allow .txt metadata to include product link and short title
- upload CLI and DouYin uploader now attach products when posting

## Testing
- `python -m py_compile utils/files_times.py cli_main.py examples/upload_video_to_douyin.py examples/upload_video_to_xhs.py examples/upload_video_to_xiaohongshu.py examples/upload_video_to_baijiahao.py examples/upload_video_to_kuaishou.py examples/upload_video_to_tencent.py examples/upload_video_to_bilibili.py examples/upload_video_to_tiktok.py uploader/douyin_uploader/main.py myUtils/postVideo.py`


------
https://chatgpt.com/codex/tasks/task_e_6899e241c040832fbdd5763cef982a05