### PR TITLE
Fix cookie path resolution and add tests

### DIFF
--- a/tests/test_files_times.py
+++ b/tests/test_files_times.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from utils.files_times import get_absolute_path
+from conf import BASE_DIR
+
+
+def test_get_absolute_path_relative():
+    result = get_absolute_path("test.json", "ks_uploader")
+    expected = str(Path(BASE_DIR) / "cookies" / "ks_uploader" / "test.json")
+    assert result == expected
+
+
+def test_get_absolute_path_absolute(tmp_path):
+    absolute = tmp_path / "my.json"
+    result = get_absolute_path(str(absolute), "ks_uploader")
+    assert result == str(absolute)

--- a/utils/files_times.py
+++ b/utils/files_times.py
@@ -2,13 +2,28 @@ from datetime import timedelta
 
 from datetime import datetime
 from pathlib import Path
+from typing import Optional, Union
 
 from conf import BASE_DIR
 
 
-def get_absolute_path(relative_path: str, base_dir: str = None) -> str:
-    # Convert the relative path to an absolute path
-    absolute_path = Path(BASE_DIR) / base_dir / relative_path
+def get_absolute_path(relative_path: Union[str, Path], base_dir: Optional[str] = None) -> str:
+    """Return an absolute path under the cookies directory.
+
+    If ``relative_path`` is already absolute it will be returned unchanged.
+    Otherwise the path will be constructed as ``BASE_DIR / "cookies" / base_dir / relative_path``.
+    ``base_dir`` is optional so callers can choose a specific uploader folder.
+    """
+
+    path = Path(relative_path)
+    if path.is_absolute():
+        return str(path)
+
+    base_path = Path(BASE_DIR) / "cookies"
+    if base_dir:
+        base_path /= base_dir
+
+    absolute_path = base_path / path
     return str(absolute_path)
 
 


### PR DESCRIPTION
## Summary
- Correct cookie path resolution to include `cookies` folder and handle absolute paths
- Add regression tests for `get_absolute_path`

## Testing
- `pytest tests/test_files_times.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899e18acdf8832f9a5f628efa5a2382